### PR TITLE
Publish

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellarjs/core",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "main": "lib-es6/index.js",
   "browser": "lib/index.browser.js",
   "src": [

--- a/packages/engine.io-client/package.json
+++ b/packages/engine.io-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellarjs/engine.io-client",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "main": "lib-es6/index.js",
   "browser": "lib/index.browser.js",
   "src": [
@@ -40,7 +40,7 @@
     "sourcemap-codec": "^1.3.0"
   },
   "dependencies": {
-    "@stellarjs/transport-socket": "^0.3.0",
+    "@stellarjs/transport-socket": "^0.3.1",
     "bluebird": "3.4.6",
     "engine.io-client": "1.7.x"
   }

--- a/packages/mw-newrelic/package.json
+++ b/packages/mw-newrelic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellarjs/mw-newrelic",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "main": "lib-es6/index.js",
   "src": [
     "src/**/*"
@@ -38,7 +38,7 @@
     "sourcemap-codec": "^1.3.0"
   },
   "dependencies": {
-    "@stellarjs/core": "^0.3.0",
+    "@stellarjs/core": "^0.3.1",
     "bluebird": "3.4.6",
     "lodash": "4.15.0",
     "newrelic": "^1.36.0"

--- a/packages/mw-rollbar/package.json
+++ b/packages/mw-rollbar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellarjs/mw-rollbar",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "main": "lib-es6/index.js",
   "src": [
     "src/**/*"
@@ -38,7 +38,7 @@
     "sourcemap-codec": "^1.3.0"
   },
   "dependencies": {
-    "@stellarjs/core": "^0.3.0",
+    "@stellarjs/core": "^0.3.1",
     "bluebird": "3.4.6",
     "rollbar": "^0.6.6"
   }

--- a/packages/transport-redis/package.json
+++ b/packages/transport-redis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellarjs/transport-redis",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "main": "lib-es6/index.js",
   "src": [
     "src/**/*"
@@ -54,7 +54,7 @@
     "sourcemap-codec": "^1.3.0"
   },
   "dependencies": {
-    "@stellarjs/core": "^0.3.0",
+    "@stellarjs/core": "^0.3.1",
     "bluebird": "3.4.7",
     "bull": "https://github.com/sloops77/bull/archive/a5135def39ae0957a682c21df362b1f67dc93c3a.tar.gz",
     "ioredis": "^2.4.0",

--- a/packages/transport-socket/package.json
+++ b/packages/transport-socket/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellarjs/transport-socket",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "main": "lib-es6/index.js",
   "browser": "lib/index.browser.js",
   "src": [
@@ -53,7 +53,7 @@
     "sourcemap-codec": "^1.3.0"
   },
   "dependencies": {
-    "@stellarjs/core": "^0.3.0",
+    "@stellarjs/core": "^0.3.1",
     "bluebird": "3.4.6",
     "lodash": "4.15.0"
   }


### PR DESCRIPTION
 - @stellarjs/core@0.3.1
 - @stellarjs/engine.io-client@0.3.1
 - @stellarjs/mw-newrelic@0.3.1
 - @stellarjs/mw-rollbar@0.3.1
 - @stellarjs/transport-redis@0.3.2
 - @stellarjs/transport-socket@0.3.1