### PR TITLE
log wasn't accessible

### DIFF
--- a/packages/mw-error-reporting/src/index.js
+++ b/packages/mw-error-reporting/src/index.js
@@ -4,7 +4,7 @@ import map from 'lodash/map';
 import Promise from 'bluebird';
 
 function errorReportingMiddleware({ reporters, ignoredErrorTypes }) {
-  return function (req, next, log) {
+  return function (req, next, options, log) {
     return next()
         .catch((err) => {
           if (includes(map(ignoredErrorTypes, 'name'), get(err, 'constructor.name'))) {


### PR DESCRIPTION
Forgot `options` param, which made `log.error` not working for me.