### PR TITLE
add bluebird to client-redux

### DIFF
--- a/packages/client-redux/package.json
+++ b/packages/client-redux/package.json
@@ -57,6 +57,7 @@
   },
   "dependencies": {
     "@stellarjs/core": "^0.10.6",
+    "bluebird": "^3.4.7",
     "lodash": "^4.17.4",
     "uuid": "^3.1.0"
   },

--- a/packages/client-redux/src/middleware.js
+++ b/packages/client-redux/src/middleware.js
@@ -2,6 +2,7 @@
  * Created by moshekabalo on 5/30/17.
  */
 import uuid from 'uuid';
+import Promise from 'bluebird';
 import unset from 'lodash/unset';
 import isFunction from 'lodash/isFunction';
 import isArray from 'lodash/isArray';

--- a/packages/client-redux/test/client-redux.test.js
+++ b/packages/client-redux/test/client-redux.test.js
@@ -1,3 +1,4 @@
+import Promise from 'bluebird';
 import reduxStellar from '../src';
 import { getActionType } from '../src/getActionType';
 import { mockAction, mockRef, mockStellarSocket } from './mocks';


### PR DESCRIPTION
caused issues in IE11

we should see if we need it as a hot-fix, then we may want to cherry-pick it to 0.10.1 (current version in prod)